### PR TITLE
Fix entity converter

### DIFF
--- a/src/main/java/com/google/sps/data/UserAccount.java
+++ b/src/main/java/com/google/sps/data/UserAccount.java
@@ -135,7 +135,7 @@ class UserAccount {
 
   public Entity convertToEntity() {
     Key key = KeyFactory.createKey(ENTITY_TYPE, this.datastoreKey);
-    Entity entity = new Entity(ENTITY_TYPE);
+    Entity entity = new Entity(key);
     entity.setProperty(USER_ID, this.userID);
     entity.setProperty(EMAIL, this.email);
     entity.setProperty(NAME, this.name);

--- a/src/main/java/com/google/sps/data/UserAccount.java
+++ b/src/main/java/com/google/sps/data/UserAccount.java
@@ -129,8 +129,13 @@ class UserAccount {
   }
 
   public Entity convertToEntity() {
-    Key key = KeyFactory.createKey(ENTITY_TYPE, this.datastoreKey);
-    Entity entity = new Entity(key);
+    Entity entity;
+    if (this.datastoreKey != 0) {
+      Key key = KeyFactory.createKey(ENTITY_TYPE, this.datastoreKey);
+      entity = new Entity(key);
+    } else {
+      entity = new Entity(ENTITY_TYPE);
+    }
     entity.setProperty(USER_ID, this.userID);
     entity.setProperty(EMAIL, this.email);
     entity.setProperty(NAME, this.name);

--- a/src/main/java/com/google/sps/data/UserAccount.java
+++ b/src/main/java/com/google/sps/data/UserAccount.java
@@ -134,13 +134,8 @@ class UserAccount {
   }
 
   public Entity convertToEntity() {
-    Entity entity;
-    if (this.datastoreKey != 0) {
-      Key key = KeyFactory.createKey(ENTITY_TYPE, this.datastoreKey);
-      entity = new Entity(key);
-    } else {
-      entity = new Entity(ENTITY_TYPE);
-    }
+    Key key = KeyFactory.createKey(ENTITY_TYPE, this.datastoreKey);
+    Entity entity = new Entity(ENTITY_TYPE);
     entity.setProperty(USER_ID, this.userID);
     entity.setProperty(EMAIL, this.email);
     entity.setProperty(NAME, this.name);

--- a/src/main/java/com/google/sps/data/UserAccount.java
+++ b/src/main/java/com/google/sps/data/UserAccount.java
@@ -1,6 +1,8 @@
 package com.google.sps.data;
 
 import com.google.appengine.api.datastore.Entity;
+import com.google.appengine.api.datastore.DatastoreService;
+import com.google.appengine.api.datastore.DatastoreServiceFactory;
 import com.google.appengine.api.datastore.Key;
 import com.google.appengine.api.datastore.KeyFactory;
 import java.util.Date;
@@ -28,6 +30,7 @@ class UserAccount {
   private static final String USER_TYPE = "userType";
 
   private long datastoreKey;
+  private boolean keyInitialized;
   private String userID;
   private String email;
   private String name;
@@ -65,7 +68,9 @@ class UserAccount {
       String educationLevelOther,
       String description,
       UserType userType) {
-    this.datastoreKey = datastoreKey;
+    DatastireService datastore = DatastoreServiceFactory.getDatastoreService();
+    KeyRange keyRange = datastore.allocateIDs(ENTITY_TYPE, 1);
+    this.datastoreKey = keyRange.getStart().getId();
     this.userID = userID;
     this.email = email;
     this.name = name;


### PR DESCRIPTION
Have datastore allocated keys for newly created user account instances (instead of having the caller of the builder to pass in a key id) to allow for datastore integrated testing and avoid duplicated profiles (a potential fallback for customized datastore keys) later on in the process.