### PR TITLE
basic structure for unit testing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,24 @@
       <version>1.9.59</version>
     </dependency>
     <dependency>
+      <groupId>com.google.appengine</groupId>
+      <artifactId>appengine-testing</artifactId>
+      <version>1.9.80</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.appengine</groupId>
+      <artifactId>appengine-api-stubs</artifactId>
+      <version>1.9.80</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.appengine</groupId>
+      <artifactId>appengine-tools-sdk</artifactId>
+      <version>1.9.80</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>com.hubspot.jinjava</groupId>
       <artifactId>jinjava</artifactId>
       <version>2.5.4</version>
@@ -42,6 +60,12 @@
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <version>3.3.3</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.12</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/test/java/com/google/sps/servlets/QuestionnaireServletTest.java
+++ b/src/test/java/com/google/sps/servlets/QuestionnaireServletTest.java
@@ -1,19 +1,37 @@
-package com.google.sps.tests;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.mock;
 
 import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
 import com.google.appengine.tools.development.testing.LocalUserServiceTestConfig;
+import com.google.appengine.api.users.UserService;
+import com.google.appengine.api.users.UserServiceFactory;
+import com.google.appengine.api.users.User;
 import com.google.sps.data.DatastoreAccess;
 import com.google.sps.servlets.QuestionnaireServlet;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import javax.servlet.RequestDispatcher;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+import javax.servlet.http.HttpServlet;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Test;
+import org.junit.Assert;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
+/**
+ * TO RUN PROJECT WITHOUT TESTS RUN COMMAND: mvn package appengine:run -DskipTests
+ * Basic structure of servlet tests using LocalServiceTestHelper for intiailizing services
+ * (dodges no api in thread error), for more help with unit testing visit:
+ * https://cloud.google.com/appengine/docs/standard/java/tools/localunittesting
+ */
 @RunWith(JUnit4.class)
 public final class QuestionnaireServletTest {
   @Mock private HttpServletRequest request;
@@ -53,5 +71,4 @@ public final class QuestionnaireServletTest {
     writer.flush();
     Assert.assertTrue(stringWriter.toString().contains("jake"));
   }
-
 }

--- a/src/test/main/java/com/google/sps/servlets/QuestionnaireServletTest.java
+++ b/src/test/main/java/com/google/sps/servlets/QuestionnaireServletTest.java
@@ -26,7 +26,7 @@ public final class QuestionnaireServletTest {
           .setEnvIsLoggedIn(true);
 
   @Before
-  public void setUp() throws Exception {
+  public void setUp() {
     MockitoAnnotations.initMocks(this);
     helper.setUp();
   }
@@ -35,4 +35,23 @@ public final class QuestionnaireServletTest {
   public void tearDown() {
     helper.tearDown();
   }
+
+  @Test
+  public void correctNameInText() throws Exception {
+    when(request.getParameter("name")).thenReturn("jake");
+    UserService userService = UserServiceFactory.getUserService();
+    when(dataAccess.getCurrentUser()).thenReturn(new User("foo@gmail.com", "gmail.com", "123"));
+
+    StringWriter stringWriter = new StringWriter();
+    PrintWriter writer = new PrintWriter(stringWriter);
+
+    when(response.getWriter()).thenReturn(writer);
+
+    servlet.doPost(request, response);
+
+    verify(request).getParameter("name");
+    writer.flush();
+    Assert.assertTrue(stringWriter.toString().contains("jake"));
+  }
+
 }

--- a/src/test/main/java/com/google/sps/servlets/QuestionnaireServletTest.java
+++ b/src/test/main/java/com/google/sps/servlets/QuestionnaireServletTest.java
@@ -1,0 +1,38 @@
+package com.google.sps.tests;
+
+import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
+import com.google.appengine.tools.development.testing.LocalUserServiceTestConfig;
+import com.google.sps.data.DatastoreAccess;
+import com.google.sps.servlets.QuestionnaireServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+@RunWith(JUnit4.class)
+public final class QuestionnaireServletTest {
+  @Mock private HttpServletRequest request;
+  @Mock private HttpServletResponse response;
+  @Mock private DatastoreAccess dataAccess;
+  @InjectMocks private QuestionnaireServlet servlet;
+  private final LocalServiceTestHelper helper =
+      new LocalServiceTestHelper(
+              new LocalUserServiceTestConfig().setOAuthUserId("foo").setOAuthEmail("foo@gmail.com"))
+          .setEnvIsLoggedIn(true);
+
+  @Before
+  public void setUp() throws Exception {
+    MockitoAnnotations.initMocks(this);
+    helper.setUp();
+  }
+
+  @After
+  public void tearDown() {
+    helper.tearDown();
+  }
+}


### PR DESCRIPTION
Structure uses QuestionnaireServlet as an example, LocalServiceTestHelper allows us to initialize any service dependencies within the test so that we may inject dependencies.

Example shows how one would inject value returns and write httpresponse to memory for testing. Example will currently fail due to dated QuestionnaireServlet.java.