### PR TITLE
remove raw strings

### DIFF
--- a/src/main/java/com/google/sps/servlets/AboutServlet.java
+++ b/src/main/java/com/google/sps/servlets/AboutServlet.java
@@ -19,6 +19,7 @@ import com.google.common.io.Resources;
 import com.google.sps.data.DummyDataAccess;
 import com.google.sps.util.ErrorMessages;
 import com.google.sps.util.ResourceConstants;
+import com.google.sps.util.ServletUtils;
 import com.google.sps.util.URLPatterns;
 import com.hubspot.jinjava.Jinjava;
 import com.hubspot.jinjava.JinjavaConfig;
@@ -68,7 +69,7 @@ public class AboutServlet extends HttpServlet {
 
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
-    response.setContentType("text/html;");
+    response.setContentType(ServletUtils.CONTENT_HTML);
 
     if (staticResponse == null) {
       response.setStatus(500);

--- a/src/main/java/com/google/sps/servlets/AuthenticateServlet.java
+++ b/src/main/java/com/google/sps/servlets/AuthenticateServlet.java
@@ -20,6 +20,8 @@ import com.google.gson.Gson;
 import com.google.sps.data.LoginState;
 import com.google.sps.data.PublicAccessPage;
 import com.google.sps.util.ErrorMessages;
+import com.google.sps.util.ParameterConstants;
+import com.google.sps.util.ServletUtils;
 import com.google.sps.util.URLPatterns;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
@@ -50,16 +52,20 @@ public class AuthenticateServlet extends HttpServlet {
       String redirUrlAfterLogout = URLPatterns.BASE;
       loginState.toggleLoginURL = userService.createLogoutURL(redirUrlAfterLogout);
       loginState.userProfileURL =
-          URLPatterns.PROFILE + "?userID=" + userService.getCurrentUser().getUserId();
+          URLPatterns.PROFILE
+              + "?"
+              + ParameterConstants.USER_ID
+              + "="
+              + userService.getCurrentUser().getUserId();
       loginState.isLoggedIn = true;
     }
-    response.setContentType("application/json");
+    response.setContentType(ServletUtils.CONTENT_JSON);
     response.getWriter().println(new Gson().toJson(loginState));
   }
 
   private String getRedirPathname(HttpServletRequest request) {
-    String encodedPathname = request.getParameter("redir");
-    if (encodedPathname == null) return URLPatterns.BASE;
+    String encodedPathname = ServletUtils.getParameter(request, ParameterConstants.REDIR, null);
+    if (encodedPathname.equals("")) return URLPatterns.BASE;
     String pathname;
     try {
       pathname = URLDecoder.decode(encodedPathname, "UTF-8");

--- a/src/main/java/com/google/sps/servlets/AuthorsServlet.java
+++ b/src/main/java/com/google/sps/servlets/AuthorsServlet.java
@@ -19,6 +19,7 @@ import com.google.common.io.Resources;
 import com.google.sps.data.DummyDataAccess;
 import com.google.sps.util.ErrorMessages;
 import com.google.sps.util.ResourceConstants;
+import com.google.sps.util.ServletUtils;
 import com.google.sps.util.URLPatterns;
 import com.hubspot.jinjava.Jinjava;
 import com.hubspot.jinjava.JinjavaConfig;
@@ -68,7 +69,7 @@ public class AuthorsServlet extends HttpServlet {
 
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
-    response.setContentType("text/html;");
+    response.setContentType(ServletUtils.CONTENT_HTML);
 
     if (staticResponse == null) {
       response.setStatus(500);

--- a/src/main/java/com/google/sps/servlets/ConnectionRequestsServlet.java
+++ b/src/main/java/com/google/sps/servlets/ConnectionRequestsServlet.java
@@ -21,8 +21,11 @@ import com.google.sps.data.DataAccess;
 import com.google.sps.data.DummyDataAccess;
 import com.google.sps.data.Mentee;
 import com.google.sps.data.MentorshipRequest;
+import com.google.sps.util.ContextFields;
 import com.google.sps.util.ErrorMessages;
+import com.google.sps.util.ParameterConstants;
 import com.google.sps.util.ResourceConstants;
+import com.google.sps.util.ServletUtils;
 import com.google.sps.util.URLPatterns;
 import com.hubspot.jinjava.Jinjava;
 import com.hubspot.jinjava.JinjavaConfig;
@@ -79,7 +82,7 @@ public class ConnectionRequestsServlet extends HttpServlet {
 
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
-    response.setContentType("text/html;");
+    response.setContentType(ServletUtils.CONTENT_HTML);
 
     if (connectionRequestTemplate == null) {
       response.setStatus(500);
@@ -88,15 +91,17 @@ public class ConnectionRequestsServlet extends HttpServlet {
 
     Map<String, Object> context =
         dataAccess.getDefaultRenderingContext(URLPatterns.CONNECTION_REQUESTS);
-    context.put("connectionRequests", dataAccess.getIncomingRequests(dataAccess.getUser("woah")));
+    context.put(
+        ContextFields.CONNECTION_REQUESTS,
+        dataAccess.getIncomingRequests(dataAccess.getUser("woah")));
     String renderTemplate = jinjava.render(connectionRequestTemplate, context);
     response.getWriter().println(renderTemplate);
   }
 
   @Override
   public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
-    final String requestKey = request.getParameter("requestID");
-    final String choice = request.getParameter("choice");
+    final String requestKey = ServletUtils.getParameter(request, ParameterConstants.REQUEST_ID, "");
+    final String choice = ServletUtils.getParameter(request, ParameterConstants.CHOICE, "");
 
     boolean success = false;
 
@@ -118,7 +123,7 @@ public class ConnectionRequestsServlet extends HttpServlet {
       }
     }
 
-    response.setContentType("application/json;");
+    response.setContentType(ServletUtils.CONTENT_JSON);
     response.getWriter().println("{\"success\": " + success + "}");
   }
 }

--- a/src/main/java/com/google/sps/servlets/DashboardServlet.java
+++ b/src/main/java/com/google/sps/servlets/DashboardServlet.java
@@ -22,8 +22,10 @@ import com.google.sps.data.DataAccess;
 import com.google.sps.data.DummyDataAccess;
 import com.google.sps.data.Mentee;
 import com.google.sps.data.Mentor;
+import com.google.sps.util.ContextFields;
 import com.google.sps.util.ErrorMessages;
 import com.google.sps.util.ResourceConstants;
+import com.google.sps.util.ServletUtils;
 import com.google.sps.util.URLPatterns;
 import com.hubspot.jinjava.Jinjava;
 import com.hubspot.jinjava.JinjavaConfig;
@@ -91,14 +93,14 @@ public class DashboardServlet extends HttpServlet {
 
     User user = dataAccess.getCurrentUser();
     if (user != null) {
-      response.setContentType("text/html;");
+      response.setContentType(ServletUtils.CONTENT_HTML);
       Map<String, Object> context = new HashMap<>();
 
       Mentor mentor = dataAccess.getMentor(user.getUserId());
       Mentee mentee = dataAccess.getMentee(user.getUserId());
       if (mentor != null) {
         Collection<Connection> connectedMentees = dataAccess.getConnections(mentor);
-        context.put("connections", connectedMentees);
+        context.put(ContextFields.CONNECTIONS, connectedMentees);
 
         String renderedTemplate = jinjava.render(dashboardMentorTemplate, context);
 
@@ -106,7 +108,7 @@ public class DashboardServlet extends HttpServlet {
         return;
       } else if (mentee != null) {
         Collection<Connection> connectedMentors = dataAccess.getConnections(mentee);
-        context.put("connections", connectedMentors);
+        context.put(ContextFields.CONNECTIONS, connectedMentors);
 
         String renderedTemplate = jinjava.render(dashboardMenteeTemplate, context);
 

--- a/src/main/java/com/google/sps/servlets/DatastoreTestServlet.java
+++ b/src/main/java/com/google/sps/servlets/DatastoreTestServlet.java
@@ -21,6 +21,7 @@ import com.google.sps.data.DatastoreAccess;
 import com.google.sps.data.DummyDataAccess;
 import com.google.sps.data.Mentee;
 import com.google.sps.data.Mentor;
+import com.google.sps.util.ServletUtils;
 import com.google.sps.util.URLPatterns;
 import java.io.IOException;
 import java.util.Collection;
@@ -37,7 +38,7 @@ public class DatastoreTestServlet extends HttpServlet {
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
     DatastoreAccess dataAccess = new DatastoreAccess();
     dataAccess.saveUser((new DummyDataAccess()).getMentor(dataAccess.getCurrentUser().getUserId()));
-    response.setContentType("application/json;");
+    response.setContentType(ServletUtils.CONTENT_JSON);
     Collection<Mentor> mentors = dataAccess.getRelatedMentors(null);
     Collection<Mentee> mentees = dataAccess.getRelatedMentees(null);
     Gson gson = new Gson();

--- a/src/main/java/com/google/sps/servlets/FindMentorServlet.java
+++ b/src/main/java/com/google/sps/servlets/FindMentorServlet.java
@@ -22,8 +22,11 @@ import com.google.sps.data.DummyDataAccess;
 import com.google.sps.data.Mentee;
 import com.google.sps.data.Mentor;
 import com.google.sps.data.MentorshipRequest;
+import com.google.sps.util.ContextFields;
 import com.google.sps.util.ErrorMessages;
+import com.google.sps.util.ParameterConstants;
 import com.google.sps.util.ResourceConstants;
+import com.google.sps.util.ServletUtils;
 import com.google.sps.util.URLPatterns;
 import com.hubspot.jinjava.Jinjava;
 import com.hubspot.jinjava.JinjavaConfig;
@@ -85,13 +88,13 @@ public class FindMentorServlet extends HttpServlet {
     if (user != null) {
       Mentee mentee = dataAccess.getMentee(user.getUserId());
       if (mentee != null) {
-        response.setContentType("text/html;");
+        response.setContentType(ServletUtils.CONTENT_HTML);
 
         Map<String, Object> context =
             dataAccess.getDefaultRenderingContext(URLPatterns.FIND_MENTOR);
 
         Collection<Mentor> relatedMentors = dataAccess.getRelatedMentors(mentee);
-        context.put("mentors", relatedMentors);
+        context.put(ContextFields.MENTORS, relatedMentors);
 
         String renderedTemplate = jinjava.render(findMentorTemplate, context);
 
@@ -104,8 +107,8 @@ public class FindMentorServlet extends HttpServlet {
 
   @Override
   public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
-    final String mentorKey = request.getParameter("mentorID");
-    final String choice = request.getParameter("choice");
+    final String mentorKey = ServletUtils.getParameter(request, ParameterConstants.MENTOR_ID, "");
+    final String choice = ServletUtils.getParameter(request, ParameterConstants.CHOICE, "");
 
     boolean success = false;
 
@@ -126,7 +129,7 @@ public class FindMentorServlet extends HttpServlet {
       }
     }
 
-    response.setContentType("application/json;");
+    response.setContentType(ServletUtils.CONTENT_JSON);
     response.getWriter().println("{\"success\": " + success + "}");
   }
 }

--- a/src/main/java/com/google/sps/servlets/LandingServlet.java
+++ b/src/main/java/com/google/sps/servlets/LandingServlet.java
@@ -19,6 +19,7 @@ import com.google.common.io.Resources;
 import com.google.sps.data.DummyDataAccess;
 import com.google.sps.util.ErrorMessages;
 import com.google.sps.util.ResourceConstants;
+import com.google.sps.util.ServletUtils;
 import com.google.sps.util.URLPatterns;
 import com.hubspot.jinjava.Jinjava;
 import com.hubspot.jinjava.JinjavaConfig;
@@ -68,7 +69,7 @@ public class LandingServlet extends HttpServlet {
 
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
-    response.setContentType("text/html;");
+    response.setContentType(ServletUtils.CONTENT_HTML);
 
     if (staticResponse == null) {
       response.setStatus(500);

--- a/src/main/java/com/google/sps/servlets/MainServlet.java
+++ b/src/main/java/com/google/sps/servlets/MainServlet.java
@@ -26,6 +26,6 @@ public class MainServlet extends HttpServlet {
 
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
-    response.sendRedirect("/landing");
+    response.sendRedirect(URLPatterns.LANDING);
   }
 }

--- a/src/main/java/com/google/sps/servlets/ProfileServlet.java
+++ b/src/main/java/com/google/sps/servlets/ProfileServlet.java
@@ -32,6 +32,7 @@ import com.google.sps.util.ContextFields;
 import com.google.sps.util.ErrorMessages;
 import com.google.sps.util.ParameterConstants;
 import com.google.sps.util.ResourceConstants;
+import com.google.sps.util.ServletUtils;
 import com.google.sps.util.URLPatterns;
 import com.hubspot.jinjava.Jinjava;
 import com.hubspot.jinjava.JinjavaConfig;
@@ -97,7 +98,7 @@ public final class ProfileServlet extends HttpServlet {
       return;
     }
 
-    String requestedUserID = getParameter(request, ParameterConstants.USER_ID, userID);
+    String requestedUserID = ServletUtils.getParameter(request, ParameterConstants.USER_ID, userID);
     Query query =
         new Query(ParameterConstants.ENTITY_TYPE_USER_ACCOUNT)
             .setFilter(
@@ -120,15 +121,7 @@ public final class ProfileServlet extends HttpServlet {
     context.put(ContextFields.PROFILE_USER, UserAccount.fromEntity(userEntity));
 
     String renderedTemplate = jinjava.render(profileTemplate, context);
-    response.setContentType("text/html;");
+    response.setContentType(ServletUtils.CONTENT_HTML);
     response.getWriter().println(renderedTemplate);
-  }
-
-  private String getParameter(HttpServletRequest request, String name, String defaultValue) {
-    String value = request.getParameter(name);
-    if (value == null || value == "") {
-      return defaultValue;
-    }
-    return value;
   }
 }

--- a/src/main/java/com/google/sps/servlets/QuestionnaireServlet.java
+++ b/src/main/java/com/google/sps/servlets/QuestionnaireServlet.java
@@ -33,6 +33,7 @@ import com.google.sps.util.ContextFields;
 import com.google.sps.util.ErrorMessages;
 import com.google.sps.util.ParameterConstants;
 import com.google.sps.util.ResourceConstants;
+import com.google.sps.util.ServletUtils;
 import com.google.sps.util.URLPatterns;
 import com.hubspot.jinjava.Jinjava;
 import com.hubspot.jinjava.JinjavaConfig;
@@ -95,14 +96,15 @@ public class QuestionnaireServlet extends HttpServlet {
 
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
-    response.setContentType("text/html;");
+    response.setContentType(ServletUtils.CONTENT_HTML);
 
     if (questionnaireTemplate == null) {
       response.setStatus(500);
       return;
     }
-    String formType = request.getParameter(ContextFields.FORM_TYPE);
-    if (formType != null && (formType.equals(MENTOR) || formType.equals(MENTEE))) {
+    String formType =
+        ServletUtils.getParameter(request, ParameterConstants.FORM_TYPE, "").toLowerCase();
+    if (formType.equals(MENTOR) || formType.equals(MENTEE)) {
       Map<String, Object> context =
           dataAccess.getDefaultRenderingContext(URLPatterns.QUESTIONNAIRE);
       context.put(ContextFields.FORM_TYPE, formType);
@@ -116,27 +118,32 @@ public class QuestionnaireServlet extends HttpServlet {
 
   @Override
   public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
-    String formType = request.getParameter(ContextFields.FORM_TYPE);
-    String name = getParameter(request, ParameterConstants.NAME, "John Doe");
+    String formType = ServletUtils.getParameter(request, ParameterConstants.FORM_TYPE, "");
+    String name = ServletUtils.getParameter(request, ParameterConstants.NAME, "John Doe");
     Date dateOfBirth;
     try {
       dateOfBirth =
           new SimpleDateFormat("yyyy-MM-dd")
-              .parse(getParameter(request, ParameterConstants.DATE_OF_BIRTH, "2000-01-01"));
+              .parse(
+                  ServletUtils.getParameter(
+                      request, ParameterConstants.DATE_OF_BIRTH, "2000-01-01"));
     } catch (ParseException e) {
       dateOfBirth = new Date();
       LOG.warning(ErrorMessages.BAD_DATE_PARSE);
     }
     Country country =
-        Country.valueOf(getParameter(request, ParameterConstants.COUNTRY, Country.US.toString()));
+        Country.valueOf(
+            ServletUtils.getParameter(request, ParameterConstants.COUNTRY, Country.US.toString()));
     TimeZone timeZone =
-        TimeZone.getTimeZone(getParameter(request, ParameterConstants.TIMEZONE, "est"));
+        TimeZone.getTimeZone(
+            ServletUtils.getParameter(request, ParameterConstants.TIMEZONE, "est"));
     Language language =
         Language.valueOf(
-            getParameter(request, ParameterConstants.LANGUAGE, Language.EN.toString()));
+            ServletUtils.getParameter(
+                request, ParameterConstants.LANGUAGE, Language.EN.toString()));
 
     ArrayList<Ethnicity> ethnicities = new ArrayList<>();
-    String ethnicityString = getParameter(request, ParameterConstants.ETHNICITY, "");
+    String ethnicityString = ServletUtils.getParameter(request, ParameterConstants.ETHNICITY, "");
     try {
       for (String ethnicity : ethnicityString.split(", ")) {
         ethnicities.add(Ethnicity.valueOf(ethnicity));
@@ -145,30 +152,37 @@ public class QuestionnaireServlet extends HttpServlet {
       LOG.warning(ErrorMessages.INVALID_PARAMATERS);
     }
 
-    String ethnicityOther = getParameter(request, ParameterConstants.ETHNICITY_OTHER, "");
-    Gender gender = Gender.valueOf(getParameter(request, ParameterConstants.GENDER, ""));
-    String genderOther = getParameter(request, ParameterConstants.GENDER_OTHER, "");
+    String ethnicityOther =
+        ServletUtils.getParameter(request, ParameterConstants.ETHNICITY_OTHER, "");
+    Gender gender =
+        Gender.valueOf(ServletUtils.getParameter(request, ParameterConstants.GENDER, ""));
+    String genderOther = ServletUtils.getParameter(request, ParameterConstants.GENDER_OTHER, "");
     EducationLevel educationLevel =
-        EducationLevel.valueOf(getParameter(request, ParameterConstants.EDUCATION_LEVEL, ""));
+        EducationLevel.valueOf(
+            ServletUtils.getParameter(request, ParameterConstants.EDUCATION_LEVEL, ""));
     String educationLevelOther =
-        getParameter(request, ParameterConstants.EDUCATION_LEVEL_OTHER, "");
+        ServletUtils.getParameter(request, ParameterConstants.EDUCATION_LEVEL_OTHER, "");
     boolean firstGen =
-        Boolean.parseBoolean(getParameter(request, ParameterConstants.FIRST_GEN, "false"));
+        Boolean.parseBoolean(
+            ServletUtils.getParameter(request, ParameterConstants.FIRST_GEN, "false"));
     boolean lowIncome =
-        Boolean.parseBoolean(getParameter(request, ParameterConstants.LOW_INCOME, "false"));
+        Boolean.parseBoolean(
+            ServletUtils.getParameter(request, ParameterConstants.LOW_INCOME, "false"));
     MentorType mentorType =
         MentorType.valueOf(
-            getParameter(request, ParameterConstants.MENTOR_TYPE, MentorType.TUTOR.toString()));
-    String description = getParameter(request, ParameterConstants.DESCRIPTION, "");
+            ServletUtils.getParameter(
+                request, ParameterConstants.MENTOR_TYPE, MentorType.TUTOR.toString()));
+    String description = ServletUtils.getParameter(request, ParameterConstants.DESCRIPTION, "");
 
     if (formType.equals(MENTEE)) {
       MeetingFrequency desiredMeetingFrequency =
           MeetingFrequency.valueOf(
-              getParameter(
+              ServletUtils.getParameter(
                   request,
                   ParameterConstants.MENTEE_DESIRED_MEETING_FREQUENCY,
                   MeetingFrequency.WEEKLY.toString()));
-      Topic goal = Topic.valueOf(getParameter(request, ParameterConstants.MENTEE_GOAL, ""));
+      Topic goal =
+          Topic.valueOf(ServletUtils.getParameter(request, ParameterConstants.MENTEE_GOAL, ""));
       dataAccess.createUser(
           (new Mentee.Builder())
               .name(name)
@@ -196,7 +210,8 @@ public class QuestionnaireServlet extends HttpServlet {
     } else {
       ArrayList<Topic> focusList = new ArrayList<>();
       String focusListString =
-          getParameter(request, ParameterConstants.MENTOR_FOCUS_LIST, Topic.OTHER.toString());
+          ServletUtils.getParameter(
+              request, ParameterConstants.MENTOR_FOCUS_LIST, Topic.OTHER.toString());
       try {
         for (String focus : focusListString.split(", ")) {
           focusList.add(Topic.valueOf(focus));
@@ -229,14 +244,6 @@ public class QuestionnaireServlet extends HttpServlet {
               .build());
       response.sendRedirect(URLPatterns.DASHBOARD);
     }
-  }
-
-  private String getParameter(HttpServletRequest request, String name, String defaultValue) {
-    String value = request.getParameter(name);
-    if (value == null || value.equals("")) {
-      value = defaultValue;
-    }
-    return value;
   }
 
   private Map<String, Object> selectionListsForFrontEnd() {

--- a/src/main/java/com/google/sps/util/ParameterConstants.java
+++ b/src/main/java/com/google/sps/util/ParameterConstants.java
@@ -47,4 +47,10 @@ public final class ParameterConstants {
   public static final String ENTITY_TYPE_CONNECTION = "Connection";
   public static final String MENTOR_KEY = "mentorKey";
   public static final String MENTEE_KEY = "menteeKey";
+
+  public static final String CHOICE = "choice";
+  public static final String FORM_TYPE = "formType";
+  public static final String MENTOR_ID = "mentorID";
+  public static final String REQUEST_ID = "requestID";
+  public static final String REDIR = "redir";
 }

--- a/src/main/java/com/google/sps/util/ServletUtils.java
+++ b/src/main/java/com/google/sps/util/ServletUtils.java
@@ -14,20 +14,18 @@
 
 package com.google.sps.util;
 
-public class ContextFields {
-  public static final String URL = "url";
-  public static final String IS_LOGGED_IN = "isLoggedIn";
-  public static final String IS_MENTOR = "isMentor";
-  public static final String IS_MENTEE = "isMentee";
-  public static final String CURRENT_USER = "currentUser";
+import javax.servlet.http.HttpServletRequest;
 
-  public static final String FORM_TYPE = "formType";
+public final class ServletUtils {
+  public static final String CONTENT_HTML = "text/html;";
+  public static final String CONTENT_JSON = "application/json;";
 
-  public static final String PROFILE_USER = "profileUser";
-
-  public static final String MENTORS = "mentors";
-
-  public static final String CONNECTION_REQUESTS = "connectionRequests";
-
-  public static final String CONNECTIONS = "connections";
+  public static String getParameter(
+      HttpServletRequest request, String parameterName, String defaultValue) {
+    String value = request.getParameter(parameterName);
+    if (value == null || value == "") {
+      return defaultValue;
+    }
+    return value;
+  }
 }

--- a/src/test/java/com/google/sps/servlets/QuestionnaireServletTest.java
+++ b/src/test/java/com/google/sps/servlets/QuestionnaireServletTest.java
@@ -1,25 +1,21 @@
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.mockito.Mockito.mock;
 
-import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
-import com.google.appengine.tools.development.testing.LocalUserServiceTestConfig;
+import com.google.appengine.api.users.User;
 import com.google.appengine.api.users.UserService;
 import com.google.appengine.api.users.UserServiceFactory;
-import com.google.appengine.api.users.User;
+import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
+import com.google.appengine.tools.development.testing.LocalUserServiceTestConfig;
 import com.google.sps.data.DatastoreAccess;
 import com.google.sps.servlets.QuestionnaireServlet;
 import java.io.PrintWriter;
 import java.io.StringWriter;
-import javax.servlet.RequestDispatcher;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import javax.servlet.http.HttpSession;
-import javax.servlet.http.HttpServlet;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.Assert;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.InjectMocks;
@@ -27,9 +23,9 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 /**
- * TO RUN PROJECT WITHOUT TESTS RUN COMMAND: mvn package appengine:run -DskipTests
- * Basic structure of servlet tests using LocalServiceTestHelper for intiailizing services
- * (dodges no api in thread error), for more help with unit testing visit:
+ * TO RUN PROJECT WITHOUT TESTS RUN COMMAND: mvn package appengine:run -DskipTests Basic structure
+ * of servlet tests using LocalServiceTestHelper for intiailizing services (dodges no api in thread
+ * error), for more help with unit testing visit:
  * https://cloud.google.com/appengine/docs/standard/java/tools/localunittesting
  */
 @RunWith(JUnit4.class)


### PR DESCRIPTION
this pr removes a bunch of raw strings ("text/html", "application/json", moving the request.getPAramter("something") to ParameterConstants, context.put("someKey") to ContextFields) to constants so we can reduce typo induced errors. I also added a ServletUtils class to get parameters from a request object with a provided default so that we dont repeat that method in all the servlets.
it's mostly replacing strings with references to constants, so not much "logical" change.