### PR TITLE
add validator to end of constructor for mentor/mentee

### DIFF
--- a/src/main/java/com/google/sps/data/Mentee.java
+++ b/src/main/java/com/google/sps/data/Mentee.java
@@ -45,7 +45,7 @@ public class Mentee extends UserAccount implements DatastoreEntity {
     this.desiredMeetingFrequency = builder.desiredMeetingFrequency;
     this.dislikedMentorKeys = builder.dislikedMentorKeys;
     this.desiredMentorType = builder.desiredMentorType;
-    this.validate();
+    this.sanitizeValues();
   }
 
   public Mentee(Entity entity) {
@@ -61,12 +61,12 @@ public class Mentee extends UserAccount implements DatastoreEntity {
             (Collection) entity.getProperty(ParameterConstants.MENTEE_DISLIKED_MENTOR_KEYS));
     this.desiredMentorType =
         MentorType.values()[toIntExact((long) entity.getProperty(ParameterConstants.MENTOR_TYPE))];
-    this.validate();
+    this.sanitizeValues();
   }
 
   @Override
-  protected void validate() {
-    super.validate();
+  protected void sanitizeValues() {
+    super.sanitizeValues();
     if (this.dislikedMentorKeys == null) {
       this.dislikedMentorKeys = new HashSet<>();
     }
@@ -84,8 +84,9 @@ public class Mentee extends UserAccount implements DatastoreEntity {
 
   /**
    * converts the list retrieved from datastore to a list of usable long values
-   * @param  dislikedMentorKeyList the list of objects from datastore
-   * @return                       the list of long values
+   *
+   * @param dislikedMentorKeyList the list of objects from datastore
+   * @return the list of long values
    */
   private static Set<Long> getDislikedSetFromProperty(Collection<Object> dislikedMentorKeyList) {
     return dislikedMentorKeyList == null

--- a/src/main/java/com/google/sps/data/Mentee.java
+++ b/src/main/java/com/google/sps/data/Mentee.java
@@ -92,9 +92,7 @@ public class Mentee extends UserAccount implements DatastoreEntity {
     return dislikedMentorKeyList == null
         ? new HashSet<Long>()
         : (Set<Long>)
-            dislikedMentorKeyList.stream()
-                .map(key -> new Long((long) key))
-                .collect(Collectors.toSet());
+            dislikedMentorKeyList.stream().map(key -> (long) key).collect(Collectors.toSet());
   }
 
   /**

--- a/src/main/java/com/google/sps/data/Mentor.java
+++ b/src/main/java/com/google/sps/data/Mentor.java
@@ -41,7 +41,7 @@ public class Mentor extends UserAccount implements DatastoreEntity {
     this.visibility = builder.visibility;
     this.focusList = builder.focusList;
     this.mentorType = builder.mentorType;
-    this.validate();
+    this.sanitizeValues();
   }
 
   public Mentor(Entity entity) {
@@ -52,12 +52,12 @@ public class Mentor extends UserAccount implements DatastoreEntity {
             (Collection) entity.getProperty(ParameterConstants.MENTOR_FOCUS_LIST));
     this.mentorType =
         MentorType.values()[toIntExact((long) entity.getProperty(ParameterConstants.MENTOR_TYPE))];
-    this.validate();
+    this.sanitizeValues();
   }
 
   @Override
-  protected void validate() {
-    super.validate();
+  protected void sanitizeValues() {
+    super.sanitizeValues();
     if (this.focusList == null) {
       this.focusList = new ArrayList<>();
     }

--- a/src/main/java/com/google/sps/data/Mentor.java
+++ b/src/main/java/com/google/sps/data/Mentor.java
@@ -36,6 +36,7 @@ public class Mentor extends UserAccount implements DatastoreEntity {
     this.visibility = builder.visibility;
     this.focusList = builder.focusList;
     this.mentorType = builder.mentorType;
+    this.validate();
   }
 
   public Mentor(Entity entity) {
@@ -46,6 +47,15 @@ public class Mentor extends UserAccount implements DatastoreEntity {
             (Collection) entity.getProperty(ParameterConstants.MENTOR_FOCUS_LIST));
     this.mentorType =
         MentorType.values()[toIntExact((long) entity.getProperty(ParameterConstants.MENTOR_TYPE))];
+    this.validate();
+  }
+
+  @Override
+  protected void validate() {
+    super.validate();
+    if (this.focusList == null) {
+      this.focusList = new ArrayList<>();
+    }
   }
 
   public Entity convertToEntity() {

--- a/src/main/java/com/google/sps/data/UserAccount.java
+++ b/src/main/java/com/google/sps/data/UserAccount.java
@@ -23,6 +23,7 @@ import com.google.appengine.api.datastore.Key;
 import com.google.appengine.api.datastore.KeyFactory;
 import com.google.appengine.api.datastore.KeyRange;
 import com.google.sps.util.ParameterConstants;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
 import java.util.TimeZone;
@@ -158,6 +159,12 @@ public class UserAccount implements DatastoreEntity {
                 == UserType.MENTEE
             ? new Mentee(entity)
             : new Mentor(entity);
+  }
+
+  protected void validate() {
+    if (this.ethnicityList == null) {
+      this.ethnicityList = new ArrayList<>();
+    }
   }
 
   public Entity convertToEntity() {

--- a/src/main/java/com/google/sps/data/UserAccount.java
+++ b/src/main/java/com/google/sps/data/UserAccount.java
@@ -165,6 +165,9 @@ public abstract class UserAccount implements DatastoreEntity {
             : new Mentor(entity);
   }
 
+  /**
+   * This method ensures that all class fields are properly initialized. If they aren't, fix it.
+   */
   protected void sanitizeValues() {
     if (this.ethnicityList == null) {
       this.ethnicityList = new ArrayList<>();

--- a/src/main/java/com/google/sps/data/UserAccount.java
+++ b/src/main/java/com/google/sps/data/UserAccount.java
@@ -34,7 +34,7 @@ import java.util.stream.Collectors;
  * can only be instantiated as a Mentee or Mentor
  * supports conversion to and from a datastore entity object
  */
-public class UserAccount implements DatastoreEntity {
+public abstract class UserAccount implements DatastoreEntity {
   private long datastoreKey;
   private boolean keyInitialized;
   private String userID;
@@ -389,10 +389,6 @@ public class UserAccount implements DatastoreEntity {
     public T userType(UserType userType) {
       this.userType = userType;
       return (T) this;
-    }
-
-    public UserAccount build() {
-      return new UserAccount(this);
     }
   }
 }

--- a/src/main/java/com/google/sps/data/UserAccount.java
+++ b/src/main/java/com/google/sps/data/UserAccount.java
@@ -165,7 +165,7 @@ public abstract class UserAccount implements DatastoreEntity {
             : new Mentor(entity);
   }
 
-  protected void validate() {
+  protected void sanitizeValues() {
     if (this.ethnicityList == null) {
       this.ethnicityList = new ArrayList<>();
     }


### PR DESCRIPTION
the datastore conversion currently doesnt have null checks. adding a validation method to the end of the user account constructors helps prevent errors when using non- primitive/enum values.