### PR TITLE
fix authenticate redirect to maintain query string

### DIFF
--- a/src/main/webapp/static/scripts/authenticate.js
+++ b/src/main/webapp/static/scripts/authenticate.js
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 function loadAuthButton() {
-  const request = '/authenticate?redir=' + encodeURIComponent(window.location.pathname);
+  const request = '/authenticate?redir=' + encodeURIComponent(window.location.pathname) + (window.location.search);
   console.log(request);
   fetch(request).then(handleFetchErrors).then(response => response.json())
     .then(loginState => {


### PR DESCRIPTION
allows for users to go directly to the questionnaire after selecting one of the two options in the landing page when they log in instead of going back to the landing page