### PR TITLE
fixed IllegalArgumentException for userType parse

### DIFF
--- a/src/main/java/com/google/sps/servlets/QuestionnaireServlet.java
+++ b/src/main/java/com/google/sps/servlets/QuestionnaireServlet.java
@@ -152,7 +152,7 @@ public class QuestionnaireServlet extends HttpServlet {
 
   private UserAccount constructNewUserFromRequest(HttpServletRequest request) {
     UserType userType =
-        UserType.valueOf(ServletUtils.getParameter(request, ContextFields.FORM_TYPE, "MENTEE"));
+        UserType.valueOf(ServletUtils.getParameter(request, ParameterConstants.FORM_TYPE, "MENTEE").toUpperCase());
     String name = ServletUtils.getParameter(request, ParameterConstants.NAME, "John Doe");
     Date dateOfBirth;
     try {


### PR DESCRIPTION
trying to parse value of formtype string was throwing an IllegalArgumentException due to not being all uppercase, this fixes that